### PR TITLE
feat: 빠른 수업 예약 - 즉시 예약 요청 및 완료 모달 추가

### DIFF
--- a/app/main/dashboard-client.tsx
+++ b/app/main/dashboard-client.tsx
@@ -12,6 +12,7 @@ import { useTodoStore } from "@/lib/useTodoStore";
 import { Modal } from "@/components/ui/Modal";
 import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
+import { useAuthStore } from "@/lib/useAuthStore";
 
 interface DashboardClientProps {
     schedules: ScheduleItem[];
@@ -63,8 +64,11 @@ export function DashboardClient({ schedules, isLoading }: DashboardClientProps) 
     // State for Quick Reserve
     const { quickTimes, activeQuickTimeId, setActiveQuickTime, addQuickTime, removeQuickTime } = useBookingStore();
     const [isQuickTimeModalOpen, setIsQuickTimeModalOpen] = useState(false);
+    const [isQuickBookingCompleteModalOpen, setIsQuickBookingCompleteModalOpen] = useState(false);
+    const [isQuickBookingSubmitting, setIsQuickBookingSubmitting] = useState(false);
     const [quickTimeForm, setQuickTimeForm] = useState({ label: "", date: today, time: "" });
     const router = useRouter();
+    const user = useAuthStore((state) => state.user);
 
     const handleAddQuickTime = () => {
         if (!quickTimeForm.label || !quickTimeForm.date || !quickTimeForm.time) {
@@ -77,17 +81,24 @@ export function DashboardClient({ schedules, isLoading }: DashboardClientProps) 
         toast.success("빠른 예약 시간이 추가되었습니다");
     };
 
-    const handleBookWithQuickTime = () => {
+    const handleBookWithQuickTime = async () => {
         if (!activeQuickTimeId) {
             toast.error("시간을 선택해주세요");
             return;
         }
 
+        if (!user?.id) {
+            toast.error("로그인이 필요합니다");
+            router.push("/login");
+            return;
+        }
+
         const selectedQuickTime = quickTimes.find((qt) => qt.id === activeQuickTimeId);
         const bookingDate = selectedQuickTime?.date;
+        const bookingTime = selectedQuickTime?.time;
 
-        if (!bookingDate) {
-            toast.error("빠른 예약 날짜를 먼저 추가해주세요");
+        if (!bookingDate || !bookingTime) {
+            toast.error("빠른 예약 날짜와 시간을 먼저 추가해주세요");
             return;
         }
 
@@ -96,7 +107,48 @@ export function DashboardClient({ schedules, isLoading }: DashboardClientProps) 
             return;
         }
 
-        router.push(`/class?quick=true&date=${bookingDate}`);
+        const dateTimeStr = `${bookingDate}T${bookingTime}:00`;
+        if (new Date(dateTimeStr) < new Date()) {
+            toast.error("과거 시점으로는 예약할 수 없습니다");
+            return;
+        }
+
+        const latestClassId = sortedSchedules.find((schedule) => schedule.class?.id)?.class?.id;
+
+        if (!latestClassId) {
+            toast.error("예약할 수업이 없습니다. 먼저 수업을 선택해주세요");
+            router.push("/class");
+            return;
+        }
+
+        setIsQuickBookingSubmitting(true);
+
+        try {
+            const response = await fetch("/api/schedules", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    classId: latestClassId,
+                    date: bookingDate,
+                    time: bookingTime,
+                    studentId: user.id,
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error(await response.text());
+            }
+
+            removeQuickTime(activeQuickTimeId);
+            setIsQuickBookingCompleteModalOpen(true);
+            toast.success("예약 신청이 완료되었습니다");
+            router.refresh();
+        } catch (error) {
+            console.error("Failed to book class with quick time", error);
+            toast.error("수업 예약에 실패했습니다");
+        } finally {
+            setIsQuickBookingSubmitting(false);
+        }
     };
 
     return (
@@ -394,9 +446,9 @@ export function DashboardClient({ schedules, isLoading }: DashboardClientProps) 
                         <Button
                             className="mt-6 w-full bg-primary text-white hover:bg-primary/90"
                             onClick={handleBookWithQuickTime}
-                            disabled={!activeQuickTimeId}
+                            disabled={!activeQuickTimeId || isQuickBookingSubmitting}
                         >
-                            선택한 시간으로 예약하기
+                            {isQuickBookingSubmitting ? "예약 신청 중..." : "선택한 시간으로 예약하기"}
                         </Button>
                     </Card>
                 </div>
@@ -445,6 +497,25 @@ export function DashboardClient({ schedules, isLoading }: DashboardClientProps) 
                             추가하기
                         </Button>
                     </div>
+                </div>
+            </Modal>
+
+            <Modal
+                isOpen={isQuickBookingCompleteModalOpen}
+                onClose={() => setIsQuickBookingCompleteModalOpen(false)}
+                title="예약 완료"
+            >
+                <div className="space-y-5">
+                    <p className="text-sm text-gray-700 leading-relaxed">
+                        빠른 수업 예약 신청이 완료되었습니다.<br />
+                        선생님의 승인을 기다려주세요.
+                    </p>
+                    <Button
+                        className="w-full bg-primary text-white"
+                        onClick={() => setIsQuickBookingCompleteModalOpen(false)}
+                    >
+                        확인
+                    </Button>
                 </div>
             </Modal>
         </main>


### PR DESCRIPTION
### Motivation
- 대시보드의 `빠른 수업 예약`에서 선택한 시간으로 바로 예약 신청할 수 있게 하여 사용자 흐름을 단순화하고, 예약 후 해당 빠른 시간이 목록에서 제거되며 완료 안내를 보여주기 위함입니다.

### Description
- `app/main/dashboard-client.tsx`에 `useAuthStore`를 도입해 로그인 상태를 확인하도록 추가했습니다.
- `handleBookWithQuickTime`를 동기 호출에서 비동기 로직으로 변경해 서버 `POST /api/schedules`를 직접 호출하도록 구현했습니다.
- 선택된 빠른 예약의 날짜/시간 및 과거 시점 검증과 로그인 검증을 추가하고, 예약 불가 상황에 대해 토스트 메시지를 표시하도록 했습니다.
- 예약 성공 시 `removeQuickTime(activeQuickTimeId)`로 목록에서 해당 항목을 제거하고 `예약 완료` 모달(`isQuickBookingCompleteModalOpen`)을 추가해 완료 안내를 표시합니다.
- 예약 중 상태를 반영하는 `isQuickBookingSubmitting` 플래그와 버튼 텍스트(`예약 신청 중...`) 및 비활성화 로직을 추가해 중복 클릭을 방지했습니다.

### Testing
- Ran linter on the modified file with `npm run lint -- app/main/dashboard-client.tsx` and it succeeded. 
- Started the dev server with `npm run dev` and confirmed the app served the `/main` page successfully. 
- Executed a Playwright screenshot script to capture the dashboard after changes and produced an artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a795f4e6a88333b7ae0e05b2da1243)